### PR TITLE
Make SwiftAbstractLogger compatible with OS X 10.10+

### DIFF
--- a/SwiftAbstractLogger.xcodeproj/project.pbxproj
+++ b/SwiftAbstractLogger.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.paulbates.${TARGET_NAME}";
 				PRODUCT_NAME = SwiftAbstractLogger;
 				USE_HEADERMAP = NO;
@@ -362,7 +362,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.paulbates.${TARGET_NAME}";
 				PRODUCT_NAME = SwiftAbstractLogger;
 				USE_HEADERMAP = NO;
@@ -773,7 +773,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.paulbates.SwiftAbstractLogger;
@@ -830,7 +830,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.paulbates.SwiftAbstractLogger;
 				SDKROOT = macosx;


### PR DESCRIPTION
The library is already compatible API-wise, it just needed the deployment target reduced.